### PR TITLE
InvalidConfig has a reasonable __str__

### DIFF
--- a/oraclebmc/exceptions.py
+++ b/oraclebmc/exceptions.py
@@ -46,6 +46,9 @@ class InvalidConfig(ClientError):
         """:param errors: {config key: error code}"""
         self.errors = errors
 
+    def __str__(self):
+        return str(self.errors)
+
 
 class InvalidPrivateKey(ClientError):
     """The provided key is not a private key, or the provided passphrase is incorrect."""


### PR DESCRIPTION
With bad config you currently get:

```
Traceback (most recent call last):
  File "flip_test.py", line 9, in <module>
    client = FlipClient(config)
  File "/home/aprasad/git/anskible/flip_client.py", line 9, in __init__
    super(FlipClient, self).__init__(config)
  File "/home/aprasad/git/anskible/bmc_sdk/local/lib/python2.7/site-packages/oraclebmc/core/virtual_network_client.py", line 19, in __init__
    validate_config(config)
  File "/home/aprasad/git/anskible/bmc_sdk/local/lib/python2.7/site-packages/oraclebmc/config.py", line 94, in validate_config
    raise InvalidConfig(errors)
oraclebmc.exceptions.InvalidConfig
```

That last line would be more useful if it showed the errors:

```oraclebmc.exceptions.InvalidConfig: {'region': 'missing'}```