### PR TITLE
Bump cryptography dependency from 1.5.2 to 1.7.2

### DIFF
--- a/oraclebmc/version.py
+++ b/oraclebmc/version.py
@@ -1,4 +1,4 @@
 # coding: utf-8
 # Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved.
 
-__version__ = "1.1.1"
+__version__ = "1.1.1post01"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 certifi
 configparser==3.5.0
 coverage==4.2
-cryptography==1.5.2
+cryptography==1.7.2
 flake8==3.0.4
 httpsig_cffi==15.0.0
 pytest==3.0.2

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ with open_relative("README.rst") as f:
 requires = [
     "certifi",
     "configparser==3.5.0",
-    "cryptography==1.5.2",
+    "cryptography==1.7.2",
     "httpsig_cffi==15.0.0",
     "python-dateutil==2.5.3",
     "pytz==2016.7",


### PR DESCRIPTION
cryptography provides compiled .whl files for Windows and OSX, but
1.5.2 does not provide wheels for Python 3.6.  The latest version
of cryptography, 1.7.2, does provide wheels for 3.6.

Signed-off-by: Joe Cross <joe.mcross@gmail.com>