### PR TITLE
Include version in pip install command

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -93,7 +93,7 @@ The supported version of OpenSSL for the Python SDK is version 1.0.1 or newer.  
 
 If the version is lower than ``1.0.1``, run the following command to bypass the version issue::
 
-    pip install requests[security]
+    pip install requests[security]==2.11.1
 
 This command instructs the `requests <https://pypi.python.org/pypi/requests>`_
 library used by the Python SDK to use the version of OpenSSL that is bundled with the `cryptography <https://pypi.python.org/pypi/cryptography>`_


### PR DESCRIPTION
Without specifying the version, you'll get requests 2.13.0, which
uses different dependencies to enable the security feature.